### PR TITLE
Add instance type and deployed package to response

### DIFF
--- a/ssp/environment.go
+++ b/ssp/environment.go
@@ -23,6 +23,7 @@ type Environment struct {
 	ID                     string `jsonapi:"primary,environments"`
 	Name                   string `jsonapi:"attr,name"`
 	BuildSHA               string `jsonapi:"attr,build_sha"`
+	BuildPackage           string `jsonapi:"attr,build_package"`
 	MaintenanceDay         time.Weekday
 	MaintenanceUnspecified bool
 	MaintenanceTime        time.Time
@@ -35,6 +36,7 @@ type Environment struct {
 	BaseEnvironment             *Environment `jsonapi:"relation,base_environment"`
 	Usage                       Usage
 	PHPVersion                  string `jsonapi:"attr,php_version"`
+	InstanceType                string `jsonapi:"attr,instance_type"`
 	OriginalUsage               string `jsonapi:"attr,usage"`
 	OriginalMaintenanceDay      string `jsonapi:"attr,maintenance_day"`
 	OriginalMaintenanceTime     string `jsonapi:"attr,maintenance_time"`

--- a/ssp/environment.go
+++ b/ssp/environment.go
@@ -36,7 +36,7 @@ type Environment struct {
 	BaseEnvironment             *Environment `jsonapi:"relation,base_environment"`
 	Usage                       Usage
 	PHPVersion                  string `jsonapi:"attr,php_version"`
-	InstanceType                string `jsonapi:"attr,instance_type"`
+	InstanceType                string `jsonapi:"attr,instance_type,omitempty"`
 	OriginalUsage               string `jsonapi:"attr,usage"`
 	OriginalMaintenanceDay      string `jsonapi:"attr,maintenance_day"`
 	OriginalMaintenanceTime     string `jsonapi:"attr,maintenance_time"`

--- a/ssp/environment_test.go
+++ b/ssp/environment_test.go
@@ -17,6 +17,7 @@ func TestGetEnvironment(t *testing.T) {
 		OriginalDesiredManifestSha:  "2.3.0",
 		PHPVersion:                  "5.6",
 		BuildPackage:                "https://example.invaid/my/package.tgz",
+		InstanceType:                "t2.small",
 	}
 	api, ts := newMockDashboard(in, http.StatusOK)
 	defer ts.Close()
@@ -51,6 +52,9 @@ func TestGetEnvironment(t *testing.T) {
 	}
 	if out.BuildPackage != in.BuildPackage {
 		t.Errorf("BuildPackage parsed incorrectly, expected '%s', got '%s'", in.BuildPackage, out.BuildPackage)
+	}
+	if out.InstanceType != in.InstanceType {
+		t.Errorf("InstanceType parsed incorrectly, expected '%s', got '%s'", in.InstanceType, out.InstanceType)
 	}
 }
 

--- a/ssp/environment_test.go
+++ b/ssp/environment_test.go
@@ -16,6 +16,7 @@ func TestGetEnvironment(t *testing.T) {
 		OriginalCurrentManifestSha:  "1.2.3",
 		OriginalDesiredManifestSha:  "2.3.0",
 		PHPVersion:                  "5.6",
+		BuildPackage:                "https://example.invaid/my/package.tgz",
 	}
 	api, ts := newMockDashboard(in, http.StatusOK)
 	defer ts.Close()
@@ -47,6 +48,9 @@ func TestGetEnvironment(t *testing.T) {
 	}
 	if out.PHPVersion != in.PHPVersion {
 		t.Errorf("PHPVersion parsed incorrectly, expected '%s', got '%s'", in.PHPVersion, out.PHPVersion)
+	}
+	if out.BuildPackage != in.BuildPackage {
+		t.Errorf("BuildPackage parsed incorrectly, expected '%s', got '%s'", in.BuildPackage, out.BuildPackage)
 	}
 }
 


### PR DESCRIPTION
Requires https://github.com/silverstripeltd/deploynaut/pull/360 to add `build_package` to api response