### PR TITLE
Add request method path to the error message

### DIFF
--- a/ssp/client.go
+++ b/ssp/client.go
@@ -18,7 +18,6 @@ package ssp
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/google/jsonapi"
 	"io"
 	"net/http"
 	"net/http/httputil"
@@ -26,6 +25,8 @@ import (
 	"os"
 	"strings"
 	"time"
+
+	"github.com/google/jsonapi"
 )
 
 // Client exposes all available SDK calls.
@@ -126,9 +127,9 @@ func (a *Client) request(method string, path string, body io.Reader) (*http.Resp
 	if resp.StatusCode > 299 {
 		er := &ErrorResponse{}
 		if err := json.NewDecoder(resp.Body).Decode(er); err == nil {
-			return nil, fmt.Errorf("HTTP %d - '%s'", resp.StatusCode, er)
+			return nil, fmt.Errorf("%s %s | HTTP %d - '%s'", method, path, resp.StatusCode, er)
 		} else {
-			return nil, fmt.Errorf("HTTP %d - '%s'", resp.StatusCode, resp.Status)
+			return nil, fmt.Errorf("%s %s | HTTP %d - '%s'", method, path, resp.StatusCode, resp.Status)
 		}
 	}
 

--- a/ssp/client_test.go
+++ b/ssp/client_test.go
@@ -2,11 +2,12 @@ package ssp
 
 import (
 	"fmt"
-	"github.com/google/jsonapi"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
+
+	"github.com/google/jsonapi"
 )
 
 func ExampleClient() {
@@ -38,6 +39,21 @@ func TestNewApi(t *testing.T) {
 
 	if api.baseURL.Host != "localhost" {
 		t.Error("BaseURL not parsed correctly")
+	}
+}
+
+func TestRequestErrorMessage(t *testing.T) {
+	api, ts := newMockDashboard(nil, http.StatusBadGateway)
+	defer ts.Close()
+	_, err := api.request("GET", "/some/path", nil)
+	if err == nil {
+		t.Errorf("Expected error, got nil error")
+	}
+
+	actual := err.Error()
+	expected := fmt.Sprintf("GET /some/path | HTTP 502 - '502 Bad Gateway'")
+	if actual != expected {
+		t.Errorf("Expected message \"%s\", got \"%s\"", expected, actual)
 	}
 }
 


### PR DESCRIPTION
Since this message bubbles up, often to the bottom of call stack it is
useful to know exactly which url and method that failed.